### PR TITLE
Godot Editor Improvements

### DIFF
--- a/content/CharacterModTemplate/project.godot
+++ b/content/CharacterModTemplate/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="CharMod"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
-config/icon="res://icon.svg"
+config/icon="res://CharMod/mod_image.png"
 
 [dotnet]
 

--- a/content/CharacterModTemplate/project.godot
+++ b/content/CharacterModTemplate/project.godot
@@ -14,6 +14,14 @@ config/name="CharMod"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
 config/icon="res://CharMod/mod_image.png"
 
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/size/initial_position_type=3
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+
 [dotnet]
 
 project/assembly_name="CharMod"
@@ -21,3 +29,4 @@ project/assembly_name="CharMod"
 [rendering]
 
 renderer/rendering_method="mobile"
+environment/defaults/default_clear_color=Color(0.0923724, 0.122398, 0.116929, 1)

--- a/content/ContentModTemplate/project.godot
+++ b/content/ContentModTemplate/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="ContentMod"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
-config/icon="res://icon.svg"
+config/icon="res://ContentMod/mod_image.png"
 
 [dotnet]
 

--- a/content/ContentModTemplate/project.godot
+++ b/content/ContentModTemplate/project.godot
@@ -14,6 +14,14 @@ config/name="ContentMod"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
 config/icon="res://ContentMod/mod_image.png"
 
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/size/initial_position_type=3
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+
 [dotnet]
 
 project/assembly_name="ContentMod"
@@ -21,3 +29,4 @@ project/assembly_name="ContentMod"
 [rendering]
 
 renderer/rendering_method="mobile"
+environment/defaults/default_clear_color=Color(0.0923724, 0.122398, 0.116929, 1)

--- a/content/ModTemplate/project.godot
+++ b/content/ModTemplate/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="ModTemplate"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
-config/icon="res://icon.svg"
+config/icon="res://ModTemplate/mod_image.png"
 
 [dotnet]
 

--- a/content/ModTemplate/project.godot
+++ b/content/ModTemplate/project.godot
@@ -14,6 +14,14 @@ config/name="ModTemplate"
 config/features=PackedStringArray("4.5", "C#", "Mobile")
 config/icon="res://ModTemplate/mod_image.png"
 
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/size/initial_position_type=3
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+
 [dotnet]
 
 project/assembly_name="ModTemplate"
@@ -21,3 +29,4 @@ project/assembly_name="ModTemplate"
 [rendering]
 
 renderer/rendering_method="mobile"
+environment/defaults/default_clear_color=Color(0.0923724, 0.122398, 0.116929, 1)


### PR DESCRIPTION
A couple of changes to improve the experience when working on a mod in the godot editor
- change godot project icon to `mod_image.png`
- change clear color (scene background color when in the editor) to the same as sts2 uses
- change viewport settings to the same as sts2 uses