### PR TITLE
add fallbacks for card image path and big card image path

### DIFF
--- a/content/CharacterModTemplate/CharModCode/Extensions/StringExtensions.cs
+++ b/content/CharacterModTemplate/CharModCode/Extensions/StringExtensions.cs
@@ -10,11 +10,22 @@ public static class StringExtensions
     
     public static string CardImagePath(this string path)
     {
-        return Path.Join(MainFile.ResPath, "images", "card_portraits", path);
+        var cardPath = Path.Join(MainFile.ResPath, "images", "card_portraits", path);
+        if (!File.Exists(cardPath))
+        {
+            cardPath = Path.Join(MainFile.ResPath, "images", "card_portraits", "card.png");
+        }
+        return cardPath;
     }
+    
     public static string BigCardImagePath(this string path)
     {
-        return Path.Join(MainFile.ResPath, "images", "card_portraits", "big", path);
+        var cardPath = Path.Join(MainFile.ResPath, "images", "card_portraits", "big", path);
+        if (!File.Exists(cardPath))
+        {
+            cardPath = Path.Join(MainFile.ResPath, "images", "card_portraits", "big", "card.png");
+        }
+        return cardPath;
     }
 
     public static string PowerImagePath(this string path)


### PR DESCRIPTION
This makes the card art fallback to the default image provided:
<img width="400" height="297" alt="image" src="https://github.com/user-attachments/assets/a1ee0962-c1e7-44d9-afe7-993f11eb0d7e" />
