### PR TITLE
Disable type 'Main' conflicts with imported type 'Main' warning sometimes caused by publicizer

### DIFF
--- a/content/CharacterModTemplate/CharMod.csproj
+++ b/content/CharacterModTemplate/CharMod.csproj
@@ -15,6 +15,8 @@
         <!-- Diasble architecture mismatch warning; mods are ideally built for all platforms (MSIL)
              while your local StS2 version will be for your specific platform. -->
         <NoWarn>$(NoWarn);MSB3270</NoWarn>
+        <!-- Disable type 'Main' conflicts with imported type 'Main' warning sometimes caused by publicizer -->
+        <NoWarn>$(NoWarn);CS0436</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="Exists('$(Sts2DataDir)')" >

--- a/content/ContentModTemplate/ContentMod.csproj
+++ b/content/ContentModTemplate/ContentMod.csproj
@@ -15,6 +15,8 @@
         <!-- Diasble architecture mismatch warning; mods are ideally built for all platforms (MSIL)
              while your local StS2 version will be for your specific platform. -->
         <NoWarn>$(NoWarn);MSB3270</NoWarn>
+        <!-- Disable type 'Main' conflicts with imported type 'Main' warning sometimes caused by publicizer -->
+        <NoWarn>$(NoWarn);CS0436</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="Exists('$(Sts2DataDir)')" >

--- a/content/ModTemplate/ModTemplate.csproj
+++ b/content/ModTemplate/ModTemplate.csproj
@@ -15,6 +15,8 @@
         <!-- Diasble architecture mismatch warning; mods are ideally built for all platforms (MSIL)
              while your local StS2 version will be for your specific platform. -->
         <NoWarn>$(NoWarn);MSB3270</NoWarn> 
+        <!-- Disable type 'Main' conflicts with imported type 'Main' warning sometimes caused by publicizer -->
+        <NoWarn>$(NoWarn);CS0436</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="Exists('$(Sts2DataDir)')" >


### PR DESCRIPTION
Disables the warning that looks like this that is sometimes caused by the publicizer

```
The type 'Main' in 'ModName/.godot/mono/temp/obj/ExportRelease/Godot.SourceGenerators/
Godot.SourceGenerators.GodotPluginsInitializerGenerator/GodotPlugins.Game.generated.cs' conflicts with the imported 
type 'Main' in 'sts2, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null'. Using the typedefined in 'ModName/.godot/
mono/temp/obj/ExportRelease/Godot.SourceGenerators/Godot.SourceGenerators.GodotPluginsInitializerGenerator/
GodotPlugins.Game.generated.cs'.
```